### PR TITLE
Document Data Creation Pipe

### DIFF
--- a/examples/run_app_examples.txt
+++ b/examples/run_app_examples.txt
@@ -4,13 +4,16 @@ runapp(program="[program]") runs a program locally
 
 #### Prompt Examples:
 
-### User: run safari
+### User: open safari
 ### Assistant: runapp(program="Safari")
 
-### User: open calendar
+### User: hey, run safari
+### Assistant: runapp(program="Safari")
+
+### User: open the calendar plase
 ### Assistant: runapp(program="calendar")
 
-### User: open vscode 
+### User: can you open vscode for me 
 ### Assistant: runapp(program="Visual Studio Code")
 
 #### Examples:

--- a/finetune/README.md
+++ b/finetune/README.md
@@ -1,25 +1,70 @@
 # Fine Tuning Steps
 
+We will fine-tune an OSS model adhere better at our instructions. This model's main purpose if formatting the instruction so we call the skill accordingly to the user request. We basically need a model that is capable of:
+- parsing the input text from whisper
+- deciding if the input text is a request for a skill
+- deciding which skill is requested
+- calling the skill with the right parameters, eg: "What is the weather in Berlin?" -> `weather(location="Berlin")`
+
+
 ## Install requirements
 
-```
-cd finetune
+> We did our experimentation on a mixture of A100, A10s and 4090s. Check the [W&B workspace here](https://wandb.ai/l2k2/otto)
+
+```bash
 pip install -r requirements_finetune.txt
 ```
 
-## Optionally generate more training data
+## Generate training data
 
+To generate the training data we need to provide a list of examples for each skill. You can check the provided examples [here](examples/). If you want to add a new skill, you will need to retrain the model to obtain the best possible performance.
+
+Each file is organized as following:
+- Prompt: This section describes the skill, for instance for the `time` skill we have:
 ```
+#### Prompt:
+timecheck(location="[location]") ask for the time at a location. 
+If no location is given it's assumed to be the current location.
+```
+then we have manually created examples of the prompts:
+```
+#### Prompt Examples:
+
+### User: What time is it now?
+### Assistant: timecheck()
+
+### User: Whats the time
+### Assistant: timecheck()
+```
+and finally we have the examples of the skill call that we can generate using OpenAI GPT that looks exactly like the prompt examples (if everything went well). I actually review them manually to make sure they are correct before appending them to the file.
+
+We are using OpenAI function calls to restrict the output format to a specific one.
+
+## Using GPT3.5-turbo/GPT-4 to generate examples
+
+This script creates the example requests using GPT. It will print the generated examples to the console. You can then copy and paste them into the example file. It generates 5 examples at a time, you can tweak this number using the `--n_generations`.
+
+
+Here we generate more examples for the `run_app` skill that opens an App on your Mac.
+
+```bash
 python training_data.py -c --file ../examples/run_app_examples.txt
 ```
 
+The provided files have already been generated using this script.
+
 ## Collect training data
 
-```
+Once you have training data generated, we convert it to a json file that will be used for training. You can use the `--files` argument to provide a list of files to convert. The script will print the json to the console, you can redirect it to a file using `> dataset/training_data.json`.
+
+```bash
 python training_data.py -t --files ../examples/*examples.txt > dataset/training_data.json
 ```
 
 ## Get base model
+
+Depending on what base model you are using, you may need to request approval from the creator team. 
+If you don't have access to Llama2 for instance, you can either use [OpenLlama](https://huggingface.co/openlm-research), [NousResearch LLama2](https://huggingface.co/NousResearch/Llama-2-7b-hf) or [MistralAI](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1). You will have to adapt the formatting of the training data to the model you are using.
 
 ## Run fine tuning
 

--- a/finetune/finetune.ipynb
+++ b/finetune/finetune.ipynb
@@ -140,10 +140,10 @@
     {
      "data": {
       "text/plain": [
-       "{'user': ['Just...',\n",
-       "  \"We'll be able to get out of here. We'll be able to get out of here. We'll be able to get out of here.\",\n",
-       "  'So you have to dry them all the way from the home side.'],\n",
-       " 'answer': ['other()', 'other()', 'other()']}"
+       "{'user': ['I know that behind the end of the watch.',\n",
+       "  'Can the voice assistant ask openai if koalas are bears?',\n",
+       "  'desire or experience emotion.'],\n",
+       " 'answer': ['other()', 'openai(prompt=\"Are koalas bears?\")', 'other()']}"
       ]
      },
      "execution_count": 6,
@@ -186,7 +186,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9b0df11733aa4fef92873c7f3cc55dd3",
+       "model_id": "4c468f63d61d42d6a9a9523a9c6d7a84",
        "version_major": 2,
        "version_minor": 0
       },
@@ -200,7 +200,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "aee636ffc9cb4db487706f154261eded",
+       "model_id": "7092d63b00ce4480abfff4a6d50b3dee",
        "version_major": 2,
        "version_minor": 0
       },
@@ -295,37 +295,82 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 69,
+   "id": "d8528f94-122b-4dc7-bbf0-4b1dc11c23d1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"You are AI that converts human request into api calls. \n",
+    "You have a set of functions:\n",
+    "-news(topic=\"[topic]\") asks for latest headlines about a topic.\n",
+    "-math(question=\"[question]\") asks a math question in python format.\n",
+    "-notes(action=\"add|list\", note=\"[note]\") lets a user take simple notes.\n",
+    "-openai(prompt=\"[prompt]\") asks openai a question.\n",
+    "-runapp(program=\"[program]\") runs a program locally.\n",
+    "-story(description=[description]) lets a user ask for a story.\n",
+    "-timecheck(location=\"[location]\") ask for the time at a location. If no location is given it's assumed to be the current location.\n",
+    "-timer(duration=\"[duration]\") sets a timer for duration written out as a string.\n",
+    "-weather(location=\"[location]\") ask for the weather at a location. If there's no location string the location is assumed to be where the user is.\n",
+    "-other() should be used when none of the other commands apply\n",
+    "\n",
+    "Here is a user request, reply with the corresponding function call, be brief.\n",
+    "USER_QUERY: \"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "64e9b126-ad58-4f45-8afd-4a071ef75826",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def _create_mistral_instruct_prompt(user, answer=\"\"):\n",
+    "    return (\"[INST] {system_prompt}{user} [/INST]\"\n",
+    "            \"{answer}\").format(user=user, answer=answer, system_prompt=system_prompt)\n",
+    "\n",
+    "def create_mistral_prompt(row): return _create_mistral_instruct_prompt(**row)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
    "id": "e5fa779d-31ae-4574-9554-166d3821cc15",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "def _create_prompt(user, answer=\"\"):\n",
+    "def _create_llama_prompt(user, answer=\"\"):\n",
     "    \"Format the prompt to style\"\n",
     "    return (\"Below is an instruction that describes a task. Write a response that appropriately completes the request.\\n\"\n",
     "            \"### User: {user}\\n\"\n",
     "            \"### Answer: {answer}\").format(user=user, answer=answer)\n",
     "\n",
-    "def create_prompt(row): return _create_prompt(**row)"
+    "def create_prompt(row): return _create_llama_prompt(**row)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 55,
    "id": "719288d3-418b-49f1-8028-a541eeebd19c",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Below is an instruction that describes a task. Write a response that appropriately completes the request.\n",
-      "### User: Just...\n",
-      "### Answer: other()\n"
+     "ename": "KeyError",
+     "evalue": "\"Invalid key: 0. Please first select a split. For example: `my_dataset_dictionary['train'][0]`. Available splits: ['test', 'train']\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-55-14754ba5e6da>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcreate_prompt\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mds\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/.local/lib/python3.8/site-packages/datasets/dataset_dict.py\u001b[0m in \u001b[0;36m__getitem__\u001b[0;34m(self, k)\u001b[0m\n\u001b[1;32m     63\u001b[0m             ]\n\u001b[1;32m     64\u001b[0m             \u001b[0msuggested_split\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mavailable_suggested_splits\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;32mif\u001b[0m \u001b[0mavailable_suggested_splits\u001b[0m \u001b[0;32melse\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 65\u001b[0;31m             raise KeyError(\n\u001b[0m\u001b[1;32m     66\u001b[0m                 \u001b[0;34mf\"Invalid key: {k}. Please first select a split. For example: \"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     67\u001b[0m                 \u001b[0;34mf\"`my_dataset_dictionary['{suggested_split}'][{k}]`. \"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mKeyError\u001b[0m: \"Invalid key: 0. Please first select a split. For example: `my_dataset_dictionary['train'][0]`. Available splits: ['test', 'train']\""
      ]
     }
    ],
@@ -335,7 +380,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
+   "id": "89db80a1-94f0-4935-a5ea-e9d04a31d87d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(create_mistral_prompt(ds[0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
    "id": "38a83c10-f88a-4085-a124-3a8c7c5c99d4",
    "metadata": {
     "tags": []
@@ -344,7 +401,8 @@
    "source": [
     "tqdm.pandas()\n",
     "\n",
-    "MODEL_NAME = 'meta-llama/Llama-2-7b-hf'\n",
+    "# MODEL_NAME = 'meta-llama/Llama-2-7b-hf'\n",
+    "MODEL_NAME = \"mistralai/Mistral-7B-Instruct-v0.1\"\n",
     "\n",
     "# Define and parse arguments.\n",
     "@dataclass\n",
@@ -360,12 +418,12 @@
     "    log_with: Optional[str] = field(default=\"wandb\", metadata={\"help\": \"use 'wandb' to log with wandb\"})\n",
     "    learning_rate: Optional[float] = field(default=1.41e-5, metadata={\"help\": \"the learning rate\"})\n",
     "    batch_size: Optional[int] = field(default=2, metadata={\"help\": \"the batch size\"})\n",
-    "    seq_length: Optional[int] = field(default=256, metadata={\"help\": \"Input sequence length\"})\n",
+    "    seq_length: Optional[int] = field(default=400, metadata={\"help\": \"Input sequence length\"})\n",
     "    gradient_accumulation_steps: Optional[int] = field(\n",
     "        default=16, metadata={\"help\": \"the number of gradient accumulation steps\"}\n",
     "    )\n",
-    "    load_in_8bit: Optional[bool] = field(default=True, metadata={\"help\": \"load the model in 8 bits precision\"})\n",
-    "    load_in_4bit: Optional[bool] = field(default=False, metadata={\"help\": \"load the model in 4 bits precision\"})\n",
+    "    load_in_8bit: Optional[bool] = field(default=False, metadata={\"help\": \"load the model in 8 bits precision\"})\n",
+    "    load_in_4bit: Optional[bool] = field(default=True, metadata={\"help\": \"load the model in 4 bits precision\"})\n",
     "    use_peft: Optional[bool] = field(default=True, metadata={\"help\": \"Wether to use PEFT or not to train adapters\"})\n",
     "    trust_remote_code: Optional[bool] = field(default=False, metadata={\"help\": \"Enable `trust_remote_code`\"})\n",
     "    output_dir: Optional[str] = field(default=\"output\", metadata={\"help\": \"the output directory\"})\n",
@@ -374,7 +432,7 @@
     "    logging_steps: Optional[int] = field(default=1, metadata={\"help\": \"the number of logging steps\"})\n",
     "    use_auth_token: Optional[bool] = field(default=True, metadata={\"help\": \"Use HF auth token to access the model\"})\n",
     "    # num_train_epochs: Optional[int] = field(default=3, metadata={\"help\": \"the number of training epochs\"})\n",
-    "    max_steps: Optional[int] = field(default=100, metadata={\"help\": \"the number of training steps\"})\n",
+    "    max_steps: Optional[int] = field(default=500, metadata={\"help\": \"the number of training steps\"})\n",
     "    save_steps: Optional[int] = field(\n",
     "        default=100, metadata={\"help\": \"Number of updates steps before two checkpoint saves\"}\n",
     "    )\n",
@@ -401,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "483710f1-ec89-47b9-a7fe-02d4e5865b41",
    "metadata": {
     "tags": []
@@ -410,10 +468,10 @@
     {
      "data": {
       "text/plain": [
-       "ScriptArguments(model_name='meta-llama/Llama-2-7b-hf', dataset_artifact='otto dataset', log_with='wandb', learning_rate=1.41e-05, batch_size=2, seq_length=256, gradient_accumulation_steps=16, load_in_8bit=True, load_in_4bit=False, use_peft=True, trust_remote_code=False, output_dir='output', peft_lora_r=64, peft_lora_alpha=16, logging_steps=1, use_auth_token=True, max_steps=100, save_steps=100, save_total_limit=10, push_to_hub=False, hub_model_id=None)"
+       "ScriptArguments(model_name='mistralai/Mistral-7B-Instruct-v0.1', dataset_artifact='otto dataset', log_with='wandb', learning_rate=1.41e-05, batch_size=2, seq_length=400, gradient_accumulation_steps=16, load_in_8bit=False, load_in_4bit=True, use_peft=True, trust_remote_code=False, output_dir='output', peft_lora_r=64, peft_lora_alpha=16, logging_steps=1, use_auth_token=True, max_steps=500, save_steps=100, save_total_limit=10, push_to_hub=False, hub_model_id=None)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -425,7 +483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "id": "286715d3-c551-40f0-93fe-064f854b550e",
    "metadata": {
     "tags": []
@@ -438,7 +496,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "id": "62b6c7e8-e5ee-4cdf-9534-87ca90a6e5d7",
    "metadata": {
     "tags": []
@@ -447,7 +505,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ee2eceec87a24f7b86e49e72cc50af06",
+       "model_id": "9747452ef6ee4edb8f01f2c88651a7ee",
        "version_major": 2,
        "version_minor": 0
       },
@@ -487,7 +545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "id": "d507a281-98c4-4454-8ce0-ed54066deddc",
    "metadata": {
     "tags": []
@@ -498,7 +556,7 @@
     "training_args = TrainingArguments(\n",
     "    output_dir=script_args.output_dir,\n",
     "    per_device_train_batch_size=script_args.batch_size,\n",
-    "    per_gpu_eval_batch_size=script_args.batch_size,\n",
+    "    per_device_eval_batch_size=script_args.batch_size,\n",
     "    gradient_accumulation_steps=script_args.gradient_accumulation_steps,\n",
     "    learning_rate=script_args.learning_rate,\n",
     "    logging_steps=script_args.logging_steps,\n",
@@ -511,6 +569,7 @@
     "    hub_model_id=script_args.hub_model_id,\n",
     ")\n",
     "\n",
+    "\n",
     "# Step 4: Define the LoraConfig\n",
     "if script_args.use_peft:\n",
     "    peft_config = LoraConfig(\n",
@@ -518,6 +577,7 @@
     "        lora_alpha=script_args.peft_lora_alpha,\n",
     "        bias=\"none\",\n",
     "        task_type=\"CAUSAL_LM\",\n",
+    "        target_modules=[\"q_proj\", \"v_proj\"],\n",
     "    )\n",
     "else:\n",
     "    peft_config = None"
@@ -536,7 +596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "id": "67c08d2c-0830-4510-b32c-ed99e3844b5d",
    "metadata": {
     "tags": []
@@ -545,10 +605,10 @@
     {
      "data": {
       "text/plain": [
-       "256"
+       "400"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -559,7 +619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "id": "07c25cbe-61bd-4dd1-aabc-de4af69535e5",
    "metadata": {
     "tags": []
@@ -578,14 +638,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "id": "9e91cec6-c81d-4331-855c-23f873487268",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "training_args.eval_steps = 5\n",
+    "training_args.eval_steps = training_args.max_steps // 5\n",
     "training_args.evaluation_strategy = \"steps\""
    ]
   },
@@ -619,7 +679,7 @@
     {
      "data": {
       "text/html": [
-       "Run data is saved locally in <code>/home/ubuntu/cape/otto/finetune/wandb/run-20231027_170141-j4mgjbaz</code>"
+       "Run data is saved locally in <code>/home/ubuntu/cape/otto/finetune/wandb/run-20231027_184445-8sp7pjtw</code>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -631,7 +691,7 @@
     {
      "data": {
       "text/html": [
-       "Syncing run <strong><a href='https://wandb.ai/capecape/otto/runs/j4mgjbaz' target=\"_blank\">whole-surf-18</a></strong> to <a href='https://wandb.ai/capecape/otto' target=\"_blank\">Weights & Biases</a> (<a href='https://wandb.me/run' target=\"_blank\">docs</a>)<br/>"
+       "Syncing run <strong><a href='https://wandb.ai/capecape/otto/runs/8sp7pjtw' target=\"_blank\">pious-frost-32</a></strong> to <a href='https://wandb.ai/capecape/otto' target=\"_blank\">Weights & Biases</a> (<a href='https://wandb.me/run' target=\"_blank\">docs</a>)<br/>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -655,7 +715,7 @@
     {
      "data": {
       "text/html": [
-       " View run at <a href='https://wandb.ai/capecape/otto/runs/j4mgjbaz' target=\"_blank\">https://wandb.ai/capecape/otto/runs/j4mgjbaz</a>"
+       " View run at <a href='https://wandb.ai/capecape/otto/runs/8sp7pjtw' target=\"_blank\">https://wandb.ai/capecape/otto/runs/8sp7pjtw</a>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -668,7 +728,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[34m\u001b[1mwandb\u001b[0m:   7 of 7 files downloaded.  \n"
+      "\u001b[34m\u001b[1mwandb\u001b[0m:   7 of 7 files downloaded.  \n",
+      "Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.\n",
+      "Using pad_token, but it is not set yet.\n"
      ]
     }
    ],
@@ -685,7 +747,7 @@
     "    args=training_args,\n",
     "    max_seq_length=script_args.seq_length,\n",
     "    packing=True,\n",
-    "    formatting_func=create_prompt,\n",
+    "    formatting_func=create_mistral_prompt,\n",
     "    peft_config=peft_config,\n",
     "    compute_metrics=token_accuracy,\n",
     ")"
@@ -706,7 +768,25 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "You're using a LlamaTokenizerFast tokenizer. Please note that with a fast tokenizer, using the `__call__` method is faster than using a method to encode the text followed by a call to the `pad` method to get a padded encoding.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'location is assumed to be where the user is.\\n-other() should be used when none of the other commands apply\\n\\nHere is a user request, convert it to the appropiate function call.\\nUSER_QUERY: And, code, these are the 4 ANSI escape codes for cursor positioning. [/INST]\\nother()</s><s> [INST] You are AI that converts human request into api calls. \\nYou have a set of functions:\\n-news(topic=\"[topic]\") asks for latest headlines about a topic.\\n-math(question=\"[question]\") asks a math question in python format.\\n-notes(action=\"add|list\", note=\"[note]\") lets a user take simple notes.\\n-openai(prompt=\"[prompt]\") asks openai a question.\\n-runapp(program=\"[program]\") runs a program locally.\\n-story(description=[description]) lets a user ask for a story.\\n-timecheck(location=\"[location]\") ask for the time at a location. If no location is given it\\'s assumed to be the current location.\\n-timer(duration=\"[duration]\") sets a timer for duration written out as a string.\\n-weather(location=\"[location]\") ask for the weather at a location. If there\\'s no location string the location is assumed to be where the user is.\\n-other() should be used when none of the other commands apply\\n\\nHere is a user request, convert it to the appropiate function call.\\nUSER_QUERY: Okay. Here. All right. [/INST]\\nother()</s><s> [INST] You are AI that converts human request into api calls. \\nYou have a set of functions:\\n-news(topic=\"[topic]\") asks for latest headlines about a topic.\\n'"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "dl = trainer.get_train_dataloader()\n",
     "b = next(iter(dl))\n",
@@ -779,21 +859,123 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 70,
    "id": "674b1b0a-e2c9-4314-853a-9f23d0a25767",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a11deb508a56458b8540664962977499",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/62 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "create_test_prompt = lambda row: {\"text\": _create_prompt(row[\"user\"], \"\")}\n",
+    "create_test_prompt = lambda row: {\"text\": _create_mistral_instruct_prompt(row[\"user\"], \"\")}\n",
     "\n",
     "test_dataset = ds[\"test\"].map(create_test_prompt)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 71,
+   "id": "847757b8-018a-48c3-b959-e087933e7769",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'[INST] You are AI that converts human request into api calls. \\nYou have a set of functions:\\n-news(topic=\"[topic]\") asks for latest headlines about a topic.\\n-math(question=\"[question]\") asks a math question in python format.\\n-notes(action=\"add|list\", note=\"[note]\") lets a user take simple notes.\\n-openai(prompt=\"[prompt]\") asks openai a question.\\n-runapp(program=\"[program]\") runs a program locally.\\n-story(description=[description]) lets a user ask for a story.\\n-timecheck(location=\"[location]\") ask for the time at a location. If no location is given it\\'s assumed to be the current location.\\n-timer(duration=\"[duration]\") sets a timer for duration written out as a string.\\n-weather(location=\"[location]\") ask for the weather at a location. If there\\'s no location string the location is assumed to be where the user is.\\n-other() should be used when none of the other commands apply\\n\\nHere is a user request, reply with the corresponding function call, be brief.\\nUSER_QUERY: Cheers! [/INST]'"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prompt = test_dataset[0][\"text\"]\n",
+    "prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "id": "feebc470-9492-470e-83e1-8c1a3094f130",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "gen_config = GenerationConfig.from_pretrained(script_args.model_name, max_new_tokens=256)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "id": "fb27c6c5-cd10-4f54-9fde-9713a6ada9aa",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'other()'"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "_generate(prompt, trainer.model, trainer.tokenizer, gen_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f10a149e-fa5d-4da7-8948-166eab833f14",
+   "metadata": {},
+   "source": [
+    "this a already pretty good!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "id": "7d5cbc5a-9068-4694-967b-78f5f2998270",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "## Let's finetune to nake it reply with the function call only!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
    "id": "d84675c1-2a8f-4c65-a66b-fdbf4607e120",
    "metadata": {
     "tags": []

--- a/finetune/finetune.ipynb
+++ b/finetune/finetune.ipynb
@@ -1,0 +1,866 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b17b3b4d-54ea-47d7-ab14-42e7b42914de",
+   "metadata": {},
+   "source": [
+    "# Finetune an OSS model for out bot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53ed8576-edd5-400b-b563-b3c16b4e3617",
+   "metadata": {},
+   "source": [
+    "We will use the [trl]() library to make our life easy! Most of the code comes from the official [trl finetune example](https://github.com/huggingface/trl/blob/main/examples/scripts/sft.py)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0a0fd751-8abf-4313-9158-26bb68751160",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# !pip install accelerate transformers datasets bitsandbytes peft trl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9961a849-6c5e-4d3f-8f87-d46406a492ef",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from dataclasses import dataclass, field\n",
+    "from typing import Optional\n",
+    "\n",
+    "import torch\n",
+    "from accelerate import Accelerator\n",
+    "from datasets import load_dataset\n",
+    "from peft import LoraConfig\n",
+    "from tqdm import tqdm\n",
+    "from transformers import AutoModelForCausalLM, BitsAndBytesConfig, HfArgumentParser, TrainingArguments\n",
+    "\n",
+    "import wandb\n",
+    "\n",
+    "from trl import SFTTrainer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc019a42-86d6-4f33-bec7-af7f73c238d9",
+   "metadata": {},
+   "source": [
+    "What is really handy here is the data preprocessing that is baked into the `SFTTrainer` class, this trainer is a thing wrapper around the transformer's `Trainer` but adds the necessary preprocessing needed to format and pack our instruction dataset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f45ab8be-1460-4aaf-891a-99f1d92d5a41",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eecd96c4-320e-463d-a664-d3b512598e72",
+   "metadata": {},
+   "source": [
+    "We will grab our dataset previously created"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2f0f25b6-c42a-43a5-b50e-d6f983ac6d38",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "training_data_path = \"dataset/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0f6a21fd-2678-4a64-93a2-504b23d7da8a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# by default the split is called train\n",
+    "ds = load_dataset(\"json\", data_files=f\"{training_data_path}/*.json\")[\"train\"].shuffle()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c77dcc18-c244-421a-a3e7-5e5974ffef5a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Dataset({\n",
+       "    features: ['user', 'answer'],\n",
+       "    num_rows: 616\n",
+       "})"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2563f6ea-f76b-4b72-b9e1-e409e8994e07",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'user': ['Just...',\n",
+       "  \"We'll be able to get out of here. We'll be able to get out of here. We'll be able to get out of here.\",\n",
+       "  'So you have to dry them all the way from the home side.'],\n",
+       " 'answer': ['other()', 'other()', 'other()']}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds[0:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7741ef5b-f1c8-475e-95b8-7cd2676ad513",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "splitted_ds = ds.train_test_split(test_size=0.1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c7a32cb-32af-4b76-a2fb-ddcba8603178",
+   "metadata": {},
+   "source": [
+    "Let's save this split in Hugging Face dataset format (fast parquet files unde the hood)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cd0eb455-145b-4e99-bb63-3fc07de87216",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9b0df11733aa4fef92873c7f3cc55dd3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Saving the dataset (0/1 shards):   0%|          | 0/554 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "aee636ffc9cb4db487706f154261eded",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Saving the dataset (0/1 shards):   0%|          | 0/62 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "splitted_ds.save_to_disk(f\"{training_data_path}/split_dataset\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6b74605-e102-4408-a450-9cc2d373531d",
+   "metadata": {},
+   "source": [
+    "Let's save this to W&B"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "5378d73a-4b2b-4e54-b371-7bc50cc218b0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# with wandb.init(project=\"otto\", job_type=\"data_split\"):\n",
+    "#     at = wandb.Artifact(name=\"split_dataset\",\n",
+    "#                         type=\"dataset\",\n",
+    "#                         description=\"The generated data splitted in 90/10\")\n",
+    "#     at.add_dir(f\"{training_data_path}/split_dataset\")\n",
+    "#     wandb.log_artifact(at)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "59f0e351-95fe-45e1-b53c-d1ff4fb3aabc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "DATASET_ARTIFACT = 'capecape/otto/split_dataset:v2'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ae72bb90-a16f-4698-9439-5c398a5e450b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from datasets import load_from_disk\n",
+    "def load_from_artifact(at_address, type=\"dataset\"):\n",
+    "    \"Load the dataset from an Artifact\"\n",
+    "    if wandb.run is not None:\n",
+    "        artifact = wandb.use_artifact(at_address, type=type)\n",
+    "    else:\n",
+    "        from wandb import Api\n",
+    "        api = Api()\n",
+    "        artifact = api.artifact(at_address, type=type)\n",
+    "    artifact_dir = artifact.download()\n",
+    "    return load_from_disk(artifact_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "530e7461-3296-43ba-b6ef-35b1ec480ac0",
+   "metadata": {},
+   "source": [
+    "## Prepare data for Training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "541a232f-a2f6-4f0c-9269-f128b3c2fba6",
+   "metadata": {},
+   "source": [
+    "> Depending on the model you will need to change this formatting function\n",
+    "\n",
+    "We will train a Llama2 model from MetaAI, depending if it is the `chat` or `vanilla` version, you will need to format your instructions differently. My to go place to find these format is the hugginface model card (but many times it is missing), the official paper (can be hard to find) or the [Axolotl training library](https://github.com/OpenAccess-AI-Collective/axolotl/blob/main/src/axolotl/prompt_strategies/llama2_chat.py)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "e5fa779d-31ae-4574-9554-166d3821cc15",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def _create_prompt(user, answer=\"\"):\n",
+    "    \"Format the prompt to style\"\n",
+    "    return (\"Below is an instruction that describes a task. Write a response that appropriately completes the request.\\n\"\n",
+    "            \"### User: {user}\\n\"\n",
+    "            \"### Answer: {answer}\").format(user=user, answer=answer)\n",
+    "\n",
+    "def create_prompt(row): return _create_prompt(**row)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "719288d3-418b-49f1-8028-a541eeebd19c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Below is an instruction that describes a task. Write a response that appropriately completes the request.\n",
+      "### User: Just...\n",
+      "### Answer: other()\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(create_prompt(ds[0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "38a83c10-f88a-4085-a124-3a8c7c5c99d4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "tqdm.pandas()\n",
+    "\n",
+    "MODEL_NAME = 'meta-llama/Llama-2-7b-hf'\n",
+    "\n",
+    "# Define and parse arguments.\n",
+    "@dataclass\n",
+    "class ScriptArguments:\n",
+    "    \"\"\"\n",
+    "    The name of the Casual LM model we wish to fine with SFTTrainer\n",
+    "    \"\"\"\n",
+    "\n",
+    "    model_name: Optional[str] = field(default=MODEL_NAME, metadata={\"help\": \"the model name\"})\n",
+    "    dataset_artifact: Optional[str] = field(\n",
+    "        default=\"otto dataset\", metadata={\"help\": \"the dataset name\"}\n",
+    "    )\n",
+    "    log_with: Optional[str] = field(default=\"wandb\", metadata={\"help\": \"use 'wandb' to log with wandb\"})\n",
+    "    learning_rate: Optional[float] = field(default=1.41e-5, metadata={\"help\": \"the learning rate\"})\n",
+    "    batch_size: Optional[int] = field(default=2, metadata={\"help\": \"the batch size\"})\n",
+    "    seq_length: Optional[int] = field(default=256, metadata={\"help\": \"Input sequence length\"})\n",
+    "    gradient_accumulation_steps: Optional[int] = field(\n",
+    "        default=16, metadata={\"help\": \"the number of gradient accumulation steps\"}\n",
+    "    )\n",
+    "    load_in_8bit: Optional[bool] = field(default=True, metadata={\"help\": \"load the model in 8 bits precision\"})\n",
+    "    load_in_4bit: Optional[bool] = field(default=False, metadata={\"help\": \"load the model in 4 bits precision\"})\n",
+    "    use_peft: Optional[bool] = field(default=True, metadata={\"help\": \"Wether to use PEFT or not to train adapters\"})\n",
+    "    trust_remote_code: Optional[bool] = field(default=False, metadata={\"help\": \"Enable `trust_remote_code`\"})\n",
+    "    output_dir: Optional[str] = field(default=\"output\", metadata={\"help\": \"the output directory\"})\n",
+    "    peft_lora_r: Optional[int] = field(default=64, metadata={\"help\": \"the r parameter of the LoRA adapters\"})\n",
+    "    peft_lora_alpha: Optional[int] = field(default=16, metadata={\"help\": \"the alpha parameter of the LoRA adapters\"})\n",
+    "    logging_steps: Optional[int] = field(default=1, metadata={\"help\": \"the number of logging steps\"})\n",
+    "    use_auth_token: Optional[bool] = field(default=True, metadata={\"help\": \"Use HF auth token to access the model\"})\n",
+    "    # num_train_epochs: Optional[int] = field(default=3, metadata={\"help\": \"the number of training epochs\"})\n",
+    "    max_steps: Optional[int] = field(default=100, metadata={\"help\": \"the number of training steps\"})\n",
+    "    save_steps: Optional[int] = field(\n",
+    "        default=100, metadata={\"help\": \"Number of updates steps before two checkpoint saves\"}\n",
+    "    )\n",
+    "    save_total_limit: Optional[int] = field(default=10, metadata={\"help\": \"Limits total number of checkpoints.\"})\n",
+    "    push_to_hub: Optional[bool] = field(default=False, metadata={\"help\": \"Push the model to HF Hub\"})\n",
+    "    hub_model_id: Optional[str] = field(default=None, metadata={\"help\": \"The name of the model on HF Hub\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "015974c7-a1ff-4687-ac33-0a626067f96e",
+   "metadata": {},
+   "source": [
+    "## Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02c7612a-87f1-4e94-9e8d-9cf0979613e2",
+   "metadata": {},
+   "source": [
+    "We can load the model with all the bells and whistles from Transformers!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "483710f1-ec89-47b9-a7fe-02d4e5865b41",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ScriptArguments(model_name='meta-llama/Llama-2-7b-hf', dataset_artifact='otto dataset', log_with='wandb', learning_rate=1.41e-05, batch_size=2, seq_length=256, gradient_accumulation_steps=16, load_in_8bit=True, load_in_4bit=False, use_peft=True, trust_remote_code=False, output_dir='output', peft_lora_r=64, peft_lora_alpha=16, logging_steps=1, use_auth_token=True, max_steps=100, save_steps=100, save_total_limit=10, push_to_hub=False, hub_model_id=None)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "script_args = ScriptArguments()\n",
+    "script_args"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "286715d3-c551-40f0-93fe-064f854b550e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# parser = HfArgumentParser(ScriptArguments)\n",
+    "# script_args = parser.parse_args_into_dataclasses()[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "62b6c7e8-e5ee-4cdf-9534-87ca90a6e5d7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ee2eceec87a24f7b86e49e72cc50af06",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Step 1: Load the model\n",
+    "if script_args.load_in_8bit and script_args.load_in_4bit:\n",
+    "    raise ValueError(\"You can't load the model in 8 bits and 4 bits at the same time\")\n",
+    "elif script_args.load_in_8bit or script_args.load_in_4bit:\n",
+    "    quantization_config = BitsAndBytesConfig(\n",
+    "        load_in_8bit=script_args.load_in_8bit, load_in_4bit=script_args.load_in_4bit\n",
+    "    )\n",
+    "    # Copy the model to each device\n",
+    "    device_map = {\"\": Accelerator().local_process_index}\n",
+    "    torch_dtype = torch.bfloat16\n",
+    "else:\n",
+    "    device_map = None\n",
+    "    quantization_config = None\n",
+    "    torch_dtype = None\n",
+    "\n",
+    "model = AutoModelForCausalLM.from_pretrained(\n",
+    "    script_args.model_name,\n",
+    "    quantization_config=quantization_config,\n",
+    "    device_map=device_map,\n",
+    "    trust_remote_code=script_args.trust_remote_code,\n",
+    "    torch_dtype=torch_dtype,\n",
+    "    use_auth_token=script_args.use_auth_token,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "d507a281-98c4-4454-8ce0-ed54066deddc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Step 3: Define the training arguments\n",
+    "training_args = TrainingArguments(\n",
+    "    output_dir=script_args.output_dir,\n",
+    "    per_device_train_batch_size=script_args.batch_size,\n",
+    "    per_gpu_eval_batch_size=script_args.batch_size,\n",
+    "    gradient_accumulation_steps=script_args.gradient_accumulation_steps,\n",
+    "    learning_rate=script_args.learning_rate,\n",
+    "    logging_steps=script_args.logging_steps,\n",
+    "    # num_train_epochs=script_args.num_train_epochs,\n",
+    "    max_steps=script_args.max_steps,\n",
+    "    report_to=script_args.log_with,\n",
+    "    save_steps=script_args.save_steps,\n",
+    "    save_total_limit=script_args.save_total_limit,\n",
+    "    push_to_hub=script_args.push_to_hub,\n",
+    "    hub_model_id=script_args.hub_model_id,\n",
+    ")\n",
+    "\n",
+    "# Step 4: Define the LoraConfig\n",
+    "if script_args.use_peft:\n",
+    "    peft_config = LoraConfig(\n",
+    "        r=script_args.peft_lora_r,\n",
+    "        lora_alpha=script_args.peft_lora_alpha,\n",
+    "        bias=\"none\",\n",
+    "        task_type=\"CAUSAL_LM\",\n",
+    "    )\n",
+    "else:\n",
+    "    peft_config = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70dfec5c-3c8b-42f2-8cc7-28f33c13d39d",
+   "metadata": {},
+   "source": [
+    "Now we need to instantiate the `SFTTrainer` with the correct preprocessing:\n",
+    "- We want to pack sequences to a certain length (longer means more memory usage)\n",
+    "- We want to tokenize\n",
+    "- We also want to apply our prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "67c08d2c-0830-4510-b32c-ed99e3844b5d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "256"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "script_args.seq_length"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "07c25cbe-61bd-4dd1-aabc-de4af69535e5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import evaluate\n",
+    "import numpy as np\n",
+    "\n",
+    "def token_accuracy(eval_preds):\n",
+    "    accuracy = evaluate.load(\"accuracy\")\n",
+    "    logits, labels = eval_preds\n",
+    "    predictions = np.argmax(logits, axis=-1)\n",
+    "    return accuracy.compute(predictions=predictions.reshape(-1), references=labels.reshape(-1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "9e91cec6-c81d-4331-855c-23f873487268",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "training_args.eval_steps = 5\n",
+    "training_args.evaluation_strategy = \"steps\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e46da0fc-8af8-4730-b218-6db315b75710",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Currently logged in as: \u001b[33mcapecape\u001b[0m. Use \u001b[1m`wandb login --relogin`\u001b[0m to force relogin\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "Tracking run with wandb version 0.15.12"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Run data is saved locally in <code>/home/ubuntu/cape/otto/finetune/wandb/run-20231027_170141-j4mgjbaz</code>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Syncing run <strong><a href='https://wandb.ai/capecape/otto/runs/j4mgjbaz' target=\"_blank\">whole-surf-18</a></strong> to <a href='https://wandb.ai/capecape/otto' target=\"_blank\">Weights & Biases</a> (<a href='https://wandb.me/run' target=\"_blank\">docs</a>)<br/>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       " View project at <a href='https://wandb.ai/capecape/otto' target=\"_blank\">https://wandb.ai/capecape/otto</a>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       " View run at <a href='https://wandb.ai/capecape/otto/runs/j4mgjbaz' target=\"_blank\">https://wandb.ai/capecape/otto/runs/j4mgjbaz</a>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m:   7 of 7 files downloaded.  \n"
+     ]
+    }
+   ],
+   "source": [
+    "wandb.init(project=\"otto\", job_type=\"finetune\")\n",
+    "    \n",
+    "ds = load_from_artifact(DATASET_ARTIFACT)\n",
+    "    \n",
+    "# Step 5: Define the Trainer\n",
+    "trainer = SFTTrainer(\n",
+    "    model=model,\n",
+    "    train_dataset=ds[\"train\"],\n",
+    "    eval_dataset=ds[\"test\"],\n",
+    "    args=training_args,\n",
+    "    max_seq_length=script_args.seq_length,\n",
+    "    packing=True,\n",
+    "    formatting_func=create_prompt,\n",
+    "    peft_config=peft_config,\n",
+    "    compute_metrics=token_accuracy,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dfd2e28-2059-4bf5-bdfa-d162d6a35978",
+   "metadata": {},
+   "source": [
+    "to be sure, let's check the dataloader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab1daacc-5a73-40a3-9ec8-cfd7c0f852b5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dl = trainer.get_train_dataloader()\n",
+    "b = next(iter(dl))\n",
+    "trainer.tokenizer.decode(b[\"input_ids\"][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75110232-61f2-4bc5-88d1-cdbc549ad127",
+   "metadata": {},
+   "source": [
+    "Let's sample from the model during Training, to do this we will add a custom WandbCallback that has access to the Trainer object (and model and tokenizer). Normally, callback don't have access to these, and that's why we need to add it to the instantiated Trainer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "444e88f5-0568-44ff-977e-d488a9faacfc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from functools import partial\n",
+    "from transformers import GenerationConfig, Trainer\n",
+    "from transformers.integrations import WandbCallback\n",
+    "\n",
+    "def has_exisiting_wandb_callback(trainer: Trainer):\n",
+    "    for item in trainer.callback_handler.callbacks:\n",
+    "        if isinstance(item, WandbCallback):\n",
+    "            return True\n",
+    "    return False\n",
+    "\n",
+    "def _generate(prompt, model, tokenizer, gen_config):\n",
+    "    tokenized_prompt = tokenizer(prompt, return_tensors='pt')['input_ids'].cuda()\n",
+    "    with torch.inference_mode():\n",
+    "        output = model.generate(inputs=tokenized_prompt, \n",
+    "                                generation_config=gen_config)\n",
+    "    return tokenizer.decode(output[0][len(tokenized_prompt[0]):], skip_special_tokens=True)\n",
+    "\n",
+    "\n",
+    "class LLMSampleCB(WandbCallback):\n",
+    "    def __init__(self, trainer, test_dataset, num_samples=10, max_new_tokens=256):\n",
+    "        super().__init__()\n",
+    "        self.sample_dataset = test_dataset.select(range(num_samples))\n",
+    "        self.gen_config = GenerationConfig.from_pretrained(trainer.model.name_or_path,\n",
+    "                                                           max_new_tokens=max_new_tokens)\n",
+    "        self.generate = partial(_generate, \n",
+    "                                model=trainer.model, \n",
+    "                                tokenizer=trainer.tokenizer, \n",
+    "                                gen_config=self.gen_config)\n",
+    "        \n",
+    "        #  we need to know if a wandb callback already exists\n",
+    "        if has_exisiting_wandb_callback(trainer):\n",
+    "            # if it does, we need to remove it\n",
+    "            trainer.callback_handler.pop_callback(WandbCallback)\n",
+    "\n",
+    "    def log_generations_table(self, examples):\n",
+    "        records_table = wandb.Table(columns=[\"prompt\", \"generation\"] + list(self.gen_config.to_dict().keys()))\n",
+    "        for example in tqdm(examples, leave=False):\n",
+    "            prompt = example[\"text\"]\n",
+    "            generation = self.generate(prompt=prompt[-1000:])\n",
+    "            records_table.add_data(prompt, generation, *list(self.gen_config.to_dict().values()))\n",
+    "        self._wandb.log({\"sample_predictions\":records_table})\n",
+    "    \n",
+    "    def on_evaluate(self, args, state, control,  **kwargs):\n",
+    "        super().on_evaluate(args, state, control, **kwargs)\n",
+    "        self.log_generations_table(self.sample_dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "674b1b0a-e2c9-4314-853a-9f23d0a25767",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "create_test_prompt = lambda row: {\"text\": _create_prompt(row[\"user\"], \"\")}\n",
+    "\n",
+    "test_dataset = ds[\"test\"].map(create_test_prompt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d84675c1-2a8f-4c65-a66b-fdbf4607e120",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "wandb_cb = LLMSampleCB(trainer, test_dataset=test_dataset, num_samples=4, max_new_tokens=256)\n",
+    "trainer.add_callback(wandb_cb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4302997f-b5e6-4115-bd03-17b0658a78e3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "trainer.train()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "167f123a-c353-46b6-b2ab-d1394c083e2d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "wandb.finish()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80823949-ed05-4d0f-8728-3da432d20c75",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Step 6: Save the model\n",
+    "trainer.save_model(script_args.output_dir)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/finetune/training_data_f.py
+++ b/finetune/training_data_f.py
@@ -1,0 +1,208 @@
+import argparse
+import json
+import re
+
+import openai
+from openai import ChatCompletion
+
+# openai.api_base = "https://api.wandb.ai/proxy/openai/v1"
+# wandb_key = os.environ["WANDB_API_KEY"]
+# openai_key = os.environ['OPENAI_API_KEY']
+# openai.api_key = f"{wandb_key}:{openai_key}"
+
+# OPENAI_MODEL = "gpt-3.5-turbo"
+OPENAI_MODEL = "gpt-4"
+TEMPERATURE = 0.7
+
+def parse_example_file(file) -> (str, list[dict], list[dict]):
+    with open(file, "r") as f:
+        cur_user_prompt = ""
+        cur_answer = ""
+        section = ""
+        line_number = 0
+        prompt = ""
+        examples = []
+        prompt_examples = []
+
+        for line in f:
+            if line.startswith("####"):
+                # section header
+                if line.startswith("#### Prompt:"):
+                    section = "prompt"
+                elif line.startswith("#### Prompt Examples:"):
+                    section = "prompt examples"
+                elif line.startswith("#### Examples:"):
+                    section = "examples"
+                else:
+                    raise ValueError(
+                        f"Malformed section header in line {line_number} in {file}"
+                    )
+            else:
+                if section == "prompt":
+                    if line.strip != "":
+                        prompt += line
+                elif section == "examples" or section == "prompt examples":
+                    if line.startswith("### User:"):
+                        if cur_user_prompt != "":
+                            raise ValueError(
+                                f"Malformed file: two user prompts in a row in line {line_number} in {file}"
+                            )
+                        # get the string after ### User:
+                        cur_user_prompt = line.split(":", 2)[1].strip()
+
+                    elif line.startswith("### Assistant:"):
+                        # get part of line after the :
+                        cur_answer = line.split(":", 1)[1].strip()
+                        example = {"user": cur_user_prompt,
+                                   "answer": cur_answer}
+                        if section == "prompt examples":
+                            prompt_examples.append(example)
+                        else:
+                            examples.append(example)
+                        cur_user_prompt = ""
+                    elif line.startswith("###"):
+                        raise ValueError(
+                            f"Malformed file: line needs to start with ### User or ### Assistant at line {line_number} in {file}"
+                        )
+
+            line_number += 1
+        return (prompt, prompt_examples, examples)
+
+
+def create_training_data_file(files):
+    examples = []
+    for file in files:
+        prompt, prompt_examples, file_examples = parse_example_file(file)
+        examples.append(file_examples)
+
+    for example in examples:
+        for line in example:
+            print(json.dumps(line))
+
+
+def prompt_examples_to_string(prompt_examples: [dict]):
+    prompt_examples_str = ""
+    for example in prompt_examples:
+        prompt_examples_str += (
+            f"### User: {example['user']}\n### Assistant: {example['answer']}\n"
+        )
+    return prompt_examples_str
+
+
+def create_prompt(prompt: str, prompt_examples: list[dict]):
+    data_collection_prompt = f"""
+I am collecting training data for a voice assistant.
+
+The voice assistant has the command:
+{prompt}
+Some examples of how a user might say this command and the response is:
+{prompt_examples_to_string(prompt_examples)}
+Generate an examples of a user querying this command and the correct response.
+
+Use the following format
+User:
+Assistant:
+"""
+
+    return data_collection_prompt
+
+format_function = [
+    {
+        "name": "validate",
+        "description": "validates the user assistant pair",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                 "user": {"type": "string", "description": "The query from the user" },
+                 "assistant":{"type": "string", "description": "The command to call" }}
+        },
+        "required": ["user", "assistant"],
+    },
+]
+
+def create_prompts(files: [str]):
+    for file in files:
+        prompt, prompt_examples, file_examples = parse_example_file(file)
+
+        data_collection_prompt = create_prompt(prompt, prompt_examples)
+        print(data_collection_prompt)
+
+
+def collect_training_data(file: str, n_generations: int=5):
+    prompt, prompt_examples, file_examples = parse_example_file(file)
+    data_collection_prompt = create_prompt(prompt, prompt_examples)
+    print(data_collection_prompt)
+
+    response = ChatCompletion.create(
+        model=OPENAI_MODEL,
+        messages=[
+            {
+                "role": "system",
+                "content": "You are helpful assistant generating training data for a voice assistant.",
+            },
+            {"role": "user", "content": data_collection_prompt},
+        ],
+        n = n_generations,
+        functions=format_function,
+        function_call = {"name": "validate"},
+        temperature=TEMPERATURE,
+    )
+    for c in response["choices"]:
+        if c.message.function_call != None:    
+            response = json.loads(c.message.function_call.arguments)
+            print("### User: {user}\n### Assistant: {assistant}\n\n".format(**response))
+
+
+def strip_ansi_codes(s):
+    return re.sub(r"\x1b\[([0-9,A-Z]{1,2}(;[0-9]{1,2})?(;[0-9]{3})?)?[m|K]?", "", s)
+
+def generate_other_examples(files):
+    lines = set()  # set of lines - want to avoid duplicates
+    for file in files:
+        with open(file, "r") as f:
+            for line in f:
+                line = strip_ansi_codes(line)
+                line = line.strip()
+                if (
+                    line == ""
+                    or line.startswith("(")
+                    or line.startswith("[")
+                    or line.startswith("*")
+                    or line.startswith(".")
+                    or line.startswith("-")
+                ):
+                    continue
+                else:
+                    lines.add(line)
+
+    for line in lines:
+        print(f"### User: {line}\n### Assistant: other()\n")
+
+
+if __name__ == "__main__":
+    argparser = argparse.ArgumentParser(
+
+        description='Generate training data from example files')
+
+    argparser.add_argument('--files', metavar='file', type=str, nargs='+',
+                           help='example files to parse')
+    argparser.add_argument('-t', '--training-data-file', action='store_true',
+                           help="generate training data file")
+    argparser.add_argument('-p', '--prompt', action='store_true',
+                           help="generate training data collection prompt")
+    argparser.add_argument('-c', '--collect-training-data', action='store_true',
+                           help="collect training data")
+    argparser.add_argument('-o', '--generate-other-examples', action='store_true',
+                           help="generate other examples")
+    argparser.add_argument('-n', '--n_generations', type=int, default=5,
+                           help="number of generations to run")
+    
+    args = argparser.parse_args()
+    if args.training_data_file:
+        create_training_data_file(args.files)
+    elif args.prompt:
+        create_prompts(args.files)
+    elif args.collect_training_data:
+        collect_training_data(args.files[0], n_generations=args.n_generations)
+    elif args.generate_other_examples:
+        generate_other_examples(args.files)

--- a/finetune/training_data_f.py
+++ b/finetune/training_data_f.py
@@ -148,10 +148,12 @@ def collect_training_data(file: str, n_generations: int=5):
         temperature=TEMPERATURE,
     )
     for c in response["choices"]:
-        if c.message.function_call != None:    
-            response = json.loads(c.message.function_call.arguments)
-            print("### User: {user}\n### Assistant: {assistant}\n\n".format(**response))
-
+        try:
+            if c.message.function_call != None:    
+                response = json.loads(c.message.function_call.arguments)
+                print("### User: {user}\n### Assistant: {assistant}\n\n".format(**response))
+        except:
+            pass
 
 def strip_ansi_codes(s):
     return re.sub(r"\x1b\[([0-9,A-Z]{1,2}(;[0-9]{1,2})?(;[0-9]{3})?)?[m|K]?", "", s)


### PR DESCRIPTION
This PR Adds descriptions to the Readme of fine-tune:
- Documents the data creation script usage
- Proposed a `training_data_f.py` script that uses OpenAI function call to force the User/Assistant output format
- Adds `--model` and `--n_generations` parameters
- Adds finetune.ipynb notebook with Mistral Instruct

Generations using GPT4 seem to more diverse results. 

> The process to save generated outputs is still manual, should we automate this? I feel that manual inspections is good. We could have some interactive way like:
```
generating 5 samples:
...
want to append those samples to "examples.txt" (y/n): y
samples appended successfully! want to generate 5 more? (y/n): n
good bye!
```